### PR TITLE
Fix deadlock race when acquire is cancelled

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -303,10 +303,6 @@ func (p *Pool) Acquire(ctx context.Context) (*Resource, error) {
 
 			select {
 			case <-ctx.Done():
-				p.cond.L.Lock()
-				p.canceledAcquireCount += 1
-				p.cond.L.Unlock()
-
 				// Allow goroutine waiting for signal to exit. Re-signal since we couldn't
 				// do anything with it. Another goroutine might be waiting.
 				go func() {
@@ -315,6 +311,9 @@ func (p *Pool) Acquire(ctx context.Context) (*Resource, error) {
 					p.cond.L.Unlock()
 				}()
 
+				p.cond.L.Lock()
+				p.canceledAcquireCount += 1
+				p.cond.L.Unlock()
 				return nil, ctx.Err()
 			case <-waitChan:
 			}


### PR DESCRIPTION
If the waiter goroutine is signaled before the section guarding canceledAcquireCount has run, then there is a deadlock because the only goroutine that can release the lock has already re-acquired it. Scheduling the second goroutine before locking ensures that one of the two can release the lock and keep things moving.