### PR TITLE
Feature CreateResource()

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -388,6 +388,7 @@ func (p *Pool) CreateResource(ctx context.Context) error {
 		creationTime: time.Now(),
 		status:       resourceStatusIdle,
 		value:        value,
+		lastUsedNano: nanotime(),
 	}
 
 	p.cond.L.Lock()

--- a/pool_test.go
+++ b/pool_test.go
@@ -573,6 +573,7 @@ func TestResourcePanicsOnUsageWhenNotAcquired(t *testing.T) {
 	assert.PanicsWithValue(t, "tried to hijack resource that is not acquired", res.Hijack)
 	assert.PanicsWithValue(t, "tried to access resource that is not acquired or hijacked", func() { res.Value() })
 	assert.PanicsWithValue(t, "tried to access resource that is not acquired or hijacked", func() { res.CreationTime() })
+	assert.PanicsWithValue(t, "tried to access resource that is not acquired or hijacked", func() { res.LastUsedNanotime() })
 	assert.PanicsWithValue(t, "tried to access resource that is not acquired or hijacked", func() { res.IdleDuration() })
 }
 


### PR DESCRIPTION
CreateResource constructs a new resource without acquiring it.
It goes straight in the IdlePool. It does not check against maxSize.
It can be useful to maintain warm resources under little load.
