### PR TITLE
Ensure that conditional variable is signaled if resource failed to cr…

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -316,6 +316,7 @@ func (p *Pool) Acquire(ctx context.Context) (*Resource, error) {
 				}
 
 				p.cond.L.Unlock()
+				p.cond.Signal()
 				return nil, err
 			}
 


### PR DESCRIPTION
Ensure that conditional variable is signaled if resource failed to create

Let's assume example:
- All resources are acquired, there are 2 goroutines (let's call them `X`, `Y`) awaiting for resource (signal on conditional variable)
- One resource is released
- Goroutine `X` is triggered by signal
- Goroutine `X` tries to create a resource, but fails with the error (unrelated reason)

Outcome:
Goroutine `Y` is not signalled and will stay there forever

Expected outcome:
Goroutine `Y` is signalled and tries to create new resource.