### PR TITLE
Fix Acquire lock issue if nil is passed as context

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -275,6 +275,9 @@ func (p *Pool) TryAcquire(ctx context.Context) (*Resource, error) {
 // doAcquire will block until a resource becomes available. If block is false, doAcquire
 // will return ErrNotAvailable if no resource is available.
 func (p *Pool) doAcquire(ctx context.Context, block bool) (*Resource, error) {
+	if ctx == nil {
+		panic("tried to acquire connection with nil context")
+	}
 	startNano := nanotime()
 	p.cond.L.Lock()
 	if doneChan := ctx.Done(); doneChan != nil {

--- a/pool_test.go
+++ b/pool_test.go
@@ -226,6 +226,15 @@ func TestPoolAcquireContextCanceledDuringCreate(t *testing.T) {
 	assert.Nil(t, res)
 }
 
+func TestPoolAcquireContextNilPanics(t *testing.T) {
+	constructor := func(ctx context.Context) (interface{}, error) {
+		panic("should never be called")
+	}
+	pool := puddle.NewPool(constructor, stubDestructor, 10)
+
+	assert.PanicsWithValue(t, "tried to acquire connection with nil context", func() { pool.Acquire(nil) })
+}
+
 func TestPoolAcquireAllIdle(t *testing.T) {
 	constructor, _ := createConstructor()
 	pool := puddle.NewPool(constructor, stubDestructor, 10)


### PR DESCRIPTION
Panic immediately if nil is used as a value for the ctx argument.

I've seen this issue just now when I mistakenly created a test case and forgot to pass a context, and then the test hang forever.

I think issue #1 is related both to pull request #12 and this one.