### PR TITLE
feat(pool): Add EmptyAcquireWaitTime stats

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -139,6 +139,7 @@ type Pool[T any] struct {
 	acquireCount         int64
 	acquireDuration      time.Duration
 	emptyAcquireCount    int64
+	emptyAcquireWaitTime time.Duration
 	canceledAcquireCount atomic.Int64
 
 	resetCount int
@@ -202,6 +203,7 @@ type Stat struct {
 	acquireCount          int64
 	acquireDuration       time.Duration
 	emptyAcquireCount     int64
+	emptyAcquireWaitTime  time.Duration
 	canceledAcquireCount  int64
 }
 
@@ -251,6 +253,13 @@ func (s *Stat) EmptyAcquireCount() int64 {
 	return s.emptyAcquireCount
 }
 
+// EmptyAcquireWaitTime returns the cumulative time waited for successful acquires
+// from the pool for a resource to be released or constructed because the pool was
+// empty.
+func (s *Stat) EmptyAcquireWaitTime() time.Duration {
+	return s.emptyAcquireWaitTime
+}
+
 // CanceledAcquireCount returns the cumulative count of acquires from the pool
 // that were canceled by a context.
 func (s *Stat) CanceledAcquireCount() int64 {
@@ -266,6 +275,7 @@ func (p *Pool[T]) Stat() *Stat {
 		maxResources:         p.maxSize,
 		acquireCount:         p.acquireCount,
 		emptyAcquireCount:    p.emptyAcquireCount,
+		emptyAcquireWaitTime: p.emptyAcquireWaitTime,
 		canceledAcquireCount: p.canceledAcquireCount.Load(),
 		acquireDuration:      p.acquireDuration,
 	}
@@ -363,11 +373,13 @@ func (p *Pool[T]) acquire(ctx context.Context) (*Resource[T], error) {
 
 	// If a resource is available in the pool.
 	if res := p.tryAcquireIdleResource(); res != nil {
+		waitTime := time.Duration(nanotime() - startNano)
 		if waitedForLock {
 			p.emptyAcquireCount += 1
+			p.emptyAcquireWaitTime += waitTime
 		}
 		p.acquireCount += 1
-		p.acquireDuration += time.Duration(nanotime() - startNano)
+		p.acquireDuration += waitTime
 		p.mux.Unlock()
 		return res, nil
 	}
@@ -391,7 +403,9 @@ func (p *Pool[T]) acquire(ctx context.Context) (*Resource[T], error) {
 
 	p.emptyAcquireCount += 1
 	p.acquireCount += 1
-	p.acquireDuration += time.Duration(nanotime() - startNano)
+	waitTime := time.Duration(nanotime() - startNano)
+	p.acquireDuration += waitTime
+	p.emptyAcquireWaitTime += waitTime
 
 	return res, nil
 }

--- a/pool_test.go
+++ b/pool_test.go
@@ -681,7 +681,7 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	stat := pool.Stat()
 	assert.Equal(t, int64(1), stat.AcquireCount())
 	assert.Equal(t, int64(1), stat.EmptyAcquireCount())
-	assert.True(t, stat.AcquireDuration() > 0, "expected stat.AcquireDuration() > 0 but %v", stat.AcquireDuration())
+	assert.Positive(t, stat.AcquireDuration(), "expected stat.AcquireDuration() > 0 but %v", stat.AcquireDuration())
 	assert.Equal(t, stat.EmptyAcquireWaitTime(), stat.AcquireDuration())
 	lastAcquireDuration := stat.AcquireDuration()
 
@@ -692,8 +692,8 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	stat = pool.Stat()
 	assert.Equal(t, int64(2), stat.AcquireCount())
 	assert.Equal(t, int64(1), stat.EmptyAcquireCount())
-	assert.True(t, stat.AcquireDuration() > lastAcquireDuration)
-	assert.True(t, stat.EmptyAcquireWaitTime() < stat.AcquireDuration())
+	assert.Greater(t, stat.AcquireDuration(), lastAcquireDuration)
+	assert.Less(t, stat.EmptyAcquireWaitTime(), stat.AcquireDuration())
 	lastAcquireDuration = stat.AcquireDuration()
 
 	wg := &sync.WaitGroup{}
@@ -713,8 +713,8 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	stat = pool.Stat()
 	assert.Equal(t, int64(4), stat.AcquireCount())
 	assert.Equal(t, int64(2), stat.EmptyAcquireCount())
-	assert.True(t, stat.AcquireDuration() > lastAcquireDuration)
-	assert.True(t, stat.EmptyAcquireWaitTime() < stat.AcquireDuration())
+	assert.Greater(t, stat.AcquireDuration(), lastAcquireDuration)
+	assert.Less(t, stat.EmptyAcquireWaitTime(), stat.AcquireDuration())
 	lastAcquireDuration = stat.AcquireDuration()
 }
 

--- a/pool_test.go
+++ b/pool_test.go
@@ -682,6 +682,7 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	assert.Equal(t, int64(1), stat.AcquireCount())
 	assert.Equal(t, int64(1), stat.EmptyAcquireCount())
 	assert.True(t, stat.AcquireDuration() > 0, "expected stat.AcquireDuration() > 0 but %v", stat.AcquireDuration())
+	assert.Equal(t, stat.EmptyAcquireWaitTime(), stat.AcquireDuration())
 	lastAcquireDuration := stat.AcquireDuration()
 
 	res, err = pool.Acquire(context.Background())
@@ -692,6 +693,7 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	assert.Equal(t, int64(2), stat.AcquireCount())
 	assert.Equal(t, int64(1), stat.EmptyAcquireCount())
 	assert.True(t, stat.AcquireDuration() > lastAcquireDuration)
+	assert.True(t, stat.EmptyAcquireWaitTime() < stat.AcquireDuration())
 	lastAcquireDuration = stat.AcquireDuration()
 
 	wg := &sync.WaitGroup{}
@@ -712,6 +714,7 @@ func TestPoolStatSuccessfulAcquireCounters(t *testing.T) {
 	assert.Equal(t, int64(4), stat.AcquireCount())
 	assert.Equal(t, int64(2), stat.EmptyAcquireCount())
 	assert.True(t, stat.AcquireDuration() > lastAcquireDuration)
+	assert.True(t, stat.EmptyAcquireWaitTime() < stat.AcquireDuration())
 	lastAcquireDuration = stat.AcquireDuration()
 }
 


### PR DESCRIPTION
This measures time for resource acquisition for cases when pool is empty and it had to wait or construct new resource.