### PR TITLE
WIP: tracing

### DIFF
--- a/pool.go
+++ b/pool.go
@@ -40,7 +40,6 @@ type Resource[T any] struct {
 	lastUsedNano   int64
 	poolResetCount int
 	status         byte
-	traceCtx       context.Context
 }
 
 // Value returns the resource value.

--- a/tracing.go
+++ b/tracing.go
@@ -5,14 +5,6 @@ import (
 	"time"
 )
 
-type traceCtxKey int
-
-const (
-	_ traceCtxKey = iota
-	acquireSpan
-	releaseSpan
-)
-
 // Tracer traces pool actions.
 type Tracer interface {
 	// AcquireStart is called at the beginning of Acquire calls. The return

--- a/tracing.go
+++ b/tracing.go
@@ -12,7 +12,7 @@ type Tracer interface {
 	AcquireStart(ctx context.Context, data AcquireStartData) context.Context
 	AcquireEnd(ctx context.Context, data AcquireEndData)
 	// ReleaseStart is called at the beginning of Release calls. The return
-	// context is used for the rest of the call and will be passed to AcquireEnd
+	// context is used for the rest of the call and will be passed to ReleaseEnd
 	ReleaseStart(ctx context.Context, data ReleaseStartData) context.Context
 	ReleaseEnd(ctx context.Context, data ReleaseEndData)
 }

--- a/tracing.go
+++ b/tracing.go
@@ -1,0 +1,111 @@
+package puddle
+
+import (
+	"context"
+	"time"
+)
+
+type traceCtxKey int
+
+const (
+	_ traceCtxKey = iota
+	acquireSpan
+	releaseSpan
+)
+
+// Tracer traces pool actions.
+type Tracer interface {
+	// AcquireStart is called at the beginning of Acquire calls. The return
+	// context is used for the rest of the call and will be passed to AcquireEnd
+	AcquireStart(ctx context.Context, data AcquireStartData) context.Context
+	AcquireEnd(ctx context.Context, data AcquireEndData)
+	// ReleaseStart is called at the beginning of Release calls. The return
+	// context is used for the rest of the call and will be passed to AcquireEnd
+	ReleaseStart(ctx context.Context, data ReleaseStartData) context.Context
+	ReleaseEnd(ctx context.Context, data ReleaseEndData)
+}
+
+type AcquireStartData struct {
+	StartNano int64
+}
+
+type AcquireEndData struct {
+	WaitDuration    time.Duration
+	AcquireDuration time.Duration
+	InitDuration    time.Duration
+	ResourceStats   ResourceTraceStats
+	Err             error
+}
+
+type ReleaseTracer interface{}
+
+type ReleaseStartData struct {
+	HeldDuration time.Duration
+}
+
+type ReleaseEndData struct {
+	BlockDuration time.Duration
+	Err           error
+}
+
+type tracerSpan struct {
+	t     Tracer
+	start int64
+}
+
+func (t tracerSpan) acquireEndErr(ctx context.Context, err error) {
+	if t.t == nil {
+		return
+	}
+	t.t.AcquireEnd(ctx, AcquireEndData{
+		AcquireDuration: time.Duration(nanotime() - t.start),
+		Err:             err,
+	})
+}
+
+func (t tracerSpan) acquireEnd(ctx context.Context, waitTime time.Duration, stats statFn, isNew bool) {
+	if t.t == nil {
+		return
+	}
+	var initDuration time.Duration
+	resourceStats := stats()
+	if isNew {
+		initDuration = time.Since(resourceStats.CreationTime)
+	}
+	t.t.AcquireEnd(ctx, AcquireEndData{
+		WaitDuration:    waitTime,
+		AcquireDuration: time.Duration(nanotime() - t.start),
+		InitDuration:    initDuration,
+		ResourceStats:   resourceStats,
+	})
+}
+
+type statFn func() ResourceTraceStats
+
+// BaseTracer implements [Tracer] methods as no-ops.
+//
+// It is intended to be composed with types that only need to implement a subset
+// of Tracer methods.
+//
+// Example usage:
+//
+//	 // MyTracer only hooks AcquireEnd
+//		type MyTracer struct {
+//			pool.BaseTracer
+//		}
+//
+//		func AcquireEnd(ctx context.Context, d AcquireEndData) {
+//	     /* do something with d */
+//		}
+type BaseTracer struct{}
+
+func (BaseTracer) AcquireStart(ctx context.Context, _ AcquireStartData) context.Context {
+	return ctx
+}
+func (BaseTracer) AcquireEnd(context.Context, AcquireEndData) {}
+func (BaseTracer) ReleaseStart(ctx context.Context, _ ReleaseStartData) context.Context {
+	return ctx
+}
+func (BaseTracer) ReleaseEnd(context.Context, ReleaseEndData) {}
+
+var _ Tracer = BaseTracer{}

--- a/tracing.go
+++ b/tracing.go
@@ -29,8 +29,6 @@ type AcquireEndData struct {
 	Err             error
 }
 
-type ReleaseTracer interface{}
-
 type ReleaseStartData struct {
 	HeldDuration time.Duration
 }


### PR DESCRIPTION
Was reading #30 and thought the [tracing idea](https://github.com/jackc/puddle/pull/30#issuecomment-1848594725) sounded interesting, so I thought I'd do a quick WIP of the idea to play around with the technique and maybe use it in my own projects. Interested in feedback.

Still fiddling with the ergonomics, but I like the abstraction of `tracerSpan` combined with defer, since it helps it get out of the way. Also not too sure what should go in `AcquireStartData` beyond the start time. It might be more useful only to track `AcquireEnd`. Maybe @jackc cares to weigh in, since you've had three years of experience with the technique now.

Ended up going with the big interface, but that's hardly solid, though splitting it up would require picking a required subset, much as pgx does with `QueryTracer`, and I'm not sure what subset that should be. The `BaseTracer` type also allows the caller to implement any subset of tracer methods and that might need adjustment if you want to ensure that implementations support both methods for each tracing type, but these are basic implementation details and easy enough to change with more granular interfaces and a new span type for each one.

Probably also want to add some benchmarking.

Happy to keep going if there's interest.